### PR TITLE
Update slf4j 1.7.21 to 1.7.32 (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
     <properties>
         <jettyVersion>9.3.10.v20160621</jettyVersion>
+        <slf4j.version>1.7.32</slf4j.version>
     </properties>
 
     <repositories>
@@ -25,12 +26,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.21</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Update slf4j 1.7.21 to 1.7.32 (CVE-2018-8088):
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088
- http://www.slf4j.org/news.html